### PR TITLE
ESP32-S2/S3 support

### DIFF
--- a/.github/workflows/arduino_build.yml
+++ b/.github/workflows/arduino_build.yml
@@ -37,6 +37,7 @@ jobs:
           arduino-board-fqbn: "esp8266:esp8266:d1_mini"
           platform-url: "https://arduino.esp8266.com/stable/package_esp8266com_index.json" 
           required-libraries: ${{ env.REQUIRED_LIBRARIES }}
+          extra-arduino-cli-args: "--warnings default"
       
       - name: Compile all examples (ESP32)
         uses: ArminJo/arduino-test-compile@v3
@@ -44,6 +45,7 @@ jobs:
           arduino-board-fqbn: "esp32:esp32:nodemcu-32s"
           platform-url: "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json"
           required-libraries: ${{ env.REQUIRED_LIBRARIES }}
+          extra-arduino-cli-args: "--warnings default"
 
       - name: Compile all examples (ESP32-S2)
         uses: ArminJo/arduino-test-compile@v3
@@ -51,6 +53,7 @@ jobs:
           arduino-board-fqbn: "esp32:esp32:esp32s2"
           platform-url: "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json"
           required-libraries: ${{ env.REQUIRED_LIBRARIES }}
+          extra-arduino-cli-args: "--warnings default"
 
       - name: Compile all examples (ESP32-S3)
         uses: ArminJo/arduino-test-compile@v3
@@ -58,3 +61,4 @@ jobs:
           arduino-board-fqbn: "esp32:esp32:esp32s3"
           platform-url: "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json"
           required-libraries: ${{ env.REQUIRED_LIBRARIES }}
+          extra-arduino-cli-args: "--warnings default"

--- a/.github/workflows/arduino_build.yml
+++ b/.github/workflows/arduino_build.yml
@@ -48,13 +48,13 @@ jobs:
       - name: Compile all examples (ESP32-S2)
         uses: ArminJo/arduino-test-compile@v3
         with:
-          arduino-board-fqbn: "esp32:esp32:ESP32S2_DEV"
+          arduino-board-fqbn: "esp32:esp32:esp32s2"
           platform-url: "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json"
           required-libraries: ${{ env.REQUIRED_LIBRARIES }}
 
       - name: Compile all examples (ESP32-S3)
         uses: ArminJo/arduino-test-compile@v3
         with:
-          arduino-board-fqbn: "esp32:esp32:ESP32S3_DEV"
+          arduino-board-fqbn: "esp32:esp32:esp32s3"
           platform-url: "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json"
           required-libraries: ${{ env.REQUIRED_LIBRARIES }}

--- a/.github/workflows/arduino_build.yml
+++ b/.github/workflows/arduino_build.yml
@@ -44,3 +44,17 @@ jobs:
           arduino-board-fqbn: "esp32:esp32:nodemcu-32s"
           platform-url: "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json"
           required-libraries: ${{ env.REQUIRED_LIBRARIES }}
+
+      - name: Compile all examples (ESP32-S2)
+        uses: ArminJo/arduino-test-compile@v3
+        with:
+          arduino-board-fqbn: "esp32:esp32:ESP32S2_DEV"
+          platform-url: "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json"
+          required-libraries: ${{ env.REQUIRED_LIBRARIES }}
+
+      - name: Compile all examples (ESP32-S3)
+        uses: ArminJo/arduino-test-compile@v3
+        with:
+          arduino-board-fqbn: "esp32:esp32:ESP32S3_DEV"
+          platform-url: "https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_dev_index.json"
+          required-libraries: ${{ env.REQUIRED_LIBRARIES }}

--- a/src/Pixie_Chroma.h
+++ b/src/Pixie_Chroma.h
@@ -63,7 +63,9 @@
 	#error "This library currently only supports ESP8266, ESP32, or TEENSY 3.X controllers. See https:\/\/github.com/connornishijima/Pixie_Chroma#supported-platforms for help."
 #endif
 
-#if defined(ARDUINO_ARCH_ESP32)
+#if defined(CONFIG_IDF_TARGET_ESP32S2)
+	#define FASTLED_ESP32_FLASH_LOCK 1
+#elif defined(ARDUINO_ARCH_ESP32)
 	#define FASTLED_ESP32_I2S true
 	#define FASTLED_RMT_MAX_CHANNELS 4
 	#define FASTLED_ESP32_FLASH_LOCK 1

--- a/src/Pixie_Chroma.h
+++ b/src/Pixie_Chroma.h
@@ -63,7 +63,7 @@
 	#error "This library currently only supports ESP8266, ESP32, or TEENSY 3.X controllers. See https:\/\/github.com/connornishijima/Pixie_Chroma#supported-platforms for help."
 #endif
 
-#if defined(CONFIG_IDF_TARGET_ESP32S2)
+#if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3)
 	#define FASTLED_ESP32_FLASH_LOCK 1
 #elif defined(ARDUINO_ARCH_ESP32)
 	#define FASTLED_ESP32_I2S true

--- a/src/pixie_chroma_internal.cpp
+++ b/src/pixie_chroma_internal.cpp
@@ -3007,7 +3007,7 @@ int16_t PixieChroma::calc_justification( t_justification justification, uint8_t 
 	x_disp_end = x_pos;
 	
 	uint8_t length = x_disp_end - x_disp_start;
-	int16_t x_offset_chars;
+	int16_t x_offset_chars = 0;
 	
 	if(length > (chars_x-2)){
 		return 0;

--- a/src/pixie_chroma_internal.cpp
+++ b/src/pixie_chroma_internal.cpp
@@ -258,7 +258,11 @@ void PixieChroma::begin_quad( uint8_t pixies_per_pin, uint8_t pixies_x, uint8_t 
 			( pixies_per_pin*leds_per_pixie )
 		).setCorrection( TypicalLEDStrip );
 		
+            #if defined( CONFIG_IDF_TARGET_ESP32S2 ) || defined( CONFIG_IDF_TARGET_ESP32S3 )
+		FastLED.addLeds<NEOPIXEL, 26>( // Initialize FastLED Data Out 4
+            #else
 		FastLED.addLeds<NEOPIXEL, 27>( // Initialize FastLED Data Out 4
+            #endif
 			color_map_out,
 			( pixies_per_pin*leds_per_pixie ) * 3,
 			( pixies_per_pin*leds_per_pixie )
@@ -2600,7 +2604,42 @@ void PixieChroma::build_controller( const uint8_t pin ){
         if ( pin == 16 ){FastLED.addLeds<WS2812B, 16, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
     #endif
     
-    #ifdef ARDUINO_ARCH_ESP32
+    #if defined( CONFIG_IDF_TARGET_ESP32S2 ) || defined( CONFIG_IDF_TARGET_ESP32S3 )
+        if ( pin == 0 ){FastLED.addLeds<WS2812B, 0, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 1 ){FastLED.addLeds<WS2812B, 1, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 2 ){FastLED.addLeds<WS2812B, 2, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 3 ){FastLED.addLeds<WS2812B, 3, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 4 ){FastLED.addLeds<WS2812B, 4, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 5 ){FastLED.addLeds<WS2812B, 5, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 12 ){FastLED.addLeds<WS2812B, 12, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 13 ){FastLED.addLeds<WS2812B, 13, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 14 ){FastLED.addLeds<WS2812B, 14, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 15 ){FastLED.addLeds<WS2812B, 15, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 16 ){FastLED.addLeds<WS2812B, 16, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 17 ){FastLED.addLeds<WS2812B, 17, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 18 ){FastLED.addLeds<WS2812B, 18, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 19 ){FastLED.addLeds<WS2812B, 19, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 21 ){FastLED.addLeds<WS2812B, 21, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 26 ){FastLED.addLeds<WS2812B, 26, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 33 ){FastLED.addLeds<WS2812B, 33, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 33 ){FastLED.addLeds<WS2812B, 33, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 34 ){FastLED.addLeds<WS2812B, 33, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 35 ){FastLED.addLeds<WS2812B, 33, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 36 ){FastLED.addLeds<WS2812B, 33, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 37 ){FastLED.addLeds<WS2812B, 33, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 38 ){FastLED.addLeds<WS2812B, 33, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 39 ){FastLED.addLeds<WS2812B, 33, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 40 ){FastLED.addLeds<WS2812B, 33, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 41 ){FastLED.addLeds<WS2812B, 33, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 42 ){FastLED.addLeds<WS2812B, 33, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 43 ){FastLED.addLeds<WS2812B, 33, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 44 ){FastLED.addLeds<WS2812B, 33, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 45 ){FastLED.addLeds<WS2812B, 33, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+      #if defined( CONFIG_IDF_TARGET_ESP32S3 )
+        if ( pin == 46 ){FastLED.addLeds<WS2812B, 33, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+        if ( pin == 47 ){FastLED.addLeds<WS2812B, 33, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
+      #endif
+    #elif ARDUINO_ARCH_ESP32
         if ( pin == 0 ){FastLED.addLeds<WS2812B, 0, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
         if ( pin == 1 ){FastLED.addLeds<WS2812B, 1, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}
         if ( pin == 2 ){FastLED.addLeds<WS2812B, 2, GRB>( color_map_out, led_count ).setCorrection( TypicalLEDStrip );}

--- a/src/pixie_chroma_internal.cpp
+++ b/src/pixie_chroma_internal.cpp
@@ -1938,7 +1938,7 @@ void PixieChroma::color_dim( uint8_t amount ){
 *///............................................................................
 void PixieChroma::draw_line_color( int16_t x1, int16_t y1, int16_t x2, int16_t y2, CRGB color ){
     //Bresenham's line algorithm
-    uint16_t index;
+    
     
     int16_t x,y,dx,dy,dx1,dy1,px,py,xe,ye,i;
     dx=x2-x1;
@@ -2020,7 +2020,7 @@ void PixieChroma::draw_line_color( int16_t x1, int16_t y1, int16_t x2, int16_t y
 *///............................................................................
 void PixieChroma::draw_line_mask( int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint8_t value ){
     //Bresenham's line algorithm
-    uint16_t index;
+    
     
     int16_t x,y,dx,dy,dx1,dy1,px,py,xe,ye,i;
     dx=x2-x1;
@@ -2779,7 +2779,7 @@ void PixieChroma::calc_xy(){
     for( uint16_t y = 0; y < matrix_height; y++ ){
         for( uint16_t x = 0; x < matrix_width; x++ ){
             uint16_t i = ( y * matrix_width ) + x;
-            uint16_t j = xy_table[i];
+            
 
             if( xy_table[i] == -2 ){
                 xy_table[i] = index;


### PR DESCRIPTION
This PR adds conditional compilation so that Chroma Pixie doesn't enable FastLED I2S support on ESP32-S2 or ESP32-S3 targets, because FastLED's I2S support doesn't build properly for them.

ESP32-S2 and ESP32-S3 targets also have different available pins from vanilla ESP32s, so this code conditionally compiles to only use the pins available on those targets and to add a few more that don't exist on vanilla ESP32s.

It also changes pin 27 to pin 26 on Quad Mode, since pin 27 isn't available on the S2 or S3. I just randomly picked pin 26 as it's allowed by FastLED.